### PR TITLE
🐛 Untrack .cargo/config.toml to prevent Windows-path leaks.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,0 @@
-[target.x86_64-unknown-linux-musl]
-rustflags = ["-C", "target-feature=+crt-static"]
-
-[target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,11 +29,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install Rust toolchain
-<<<<<<< HEAD
         uses: dtolnay/rust-toolchain@master
-=======
-        uses: dtolnay/rust-toolchain@stable
->>>>>>> origin/dev
         with:
           toolchain: ${{ matrix.rust }}
           components: rustfmt, clippy
@@ -72,11 +68,7 @@ jobs:
 
       - name: Ensure Python3 present
         if: startsWith(matrix.os, 'ubuntu') && matrix.rust == 'stable'
-<<<<<<< HEAD
         uses: actions/setup-python@v4
-=======
-        uses: actions/setup-python@v5
->>>>>>> origin/dev
         with:
           python-version: "3.x"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,11 +68,7 @@ jobs:
 
       - name: System Packages — Cache (Linux only)
         if: matrix.platform.os == 'ubuntu-24.04' || matrix.platform.os == 'ubuntu-24.04-arm'
-<<<<<<< HEAD
         uses: awalsh128/cache-apt-pkgs-action@latest
-=======
-        uses: awalsh128/cache-apt-pkgs-action@v1
->>>>>>> origin/dev
         with:
           packages: |
             build-essential
@@ -97,11 +93,7 @@ jobs:
 
       - name: System Packages — Cache (i686 — 32-bit libs)
         if: matrix.platform.target == 'i686-unknown-linux-gnu'
-<<<<<<< HEAD
         uses: awalsh128/cache-apt-pkgs-action@latest
-=======
-        uses: awalsh128/cache-apt-pkgs-action@v1
->>>>>>> origin/dev
         with:
           packages: |
             gcc-multilib
@@ -160,11 +152,7 @@ jobs:
           echo "pkg_config_allow_cross=${PKG_CONFIG_ALLOW_CROSS}" >> $GITHUB_OUTPUT
 
       - name: Install stable Rust toolchain
-<<<<<<< HEAD
         uses: dtolnay/rust-toolchain@master
-=======
-        uses: dtolnay/rust-toolchain@stable
->>>>>>> origin/dev
         with:
           toolchain: "stable"
           targets: ${{ matrix.platform.target }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,5 @@
 target
-<<<<<<< HEAD
 Cargo.lock
-=======
->>>>>>> origin/dev
 
 *.log
 
@@ -19,7 +16,6 @@ Cargo.lock
 *.orig
 __pycache__/
 *.pyc
-<<<<<<< HEAD
 =======
 
 # Python cache
@@ -37,15 +33,4 @@ ci-results/
 
 res/about_cache.toml
 <<<<<<< HEAD
-=======
-
-# Cargo lockfile (not tracked)
-/Cargo.lock
-
-dist/
-
-# celestia-devtools: staged-on-demand shared justfile recipes (just fetch)
-/.just/
-/celestia-devtools.just
-.trae/
->>>>>>> origin/dev
+.cargo/config.toml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,7 @@
 name = "aoba"
 description.workspace = true
 repository.workspace = true
-<<<<<<< HEAD
 license.workspace = true
-=======
->>>>>>> origin/dev
 license-file = "LICENSE"
 authors.workspace = true
 version.workspace = true

--- a/build.rs
+++ b/build.rs
@@ -38,21 +38,7 @@ fn main() -> Result<()> {
                             TomlValue::String(repo.to_string()),
                         );
                     }
-<<<<<<< HEAD
                     if let Some(lic) = t.get("license").and_then(|x| x.as_str()) {
-=======
-                    // License: prefer the package-level field, fall back to the
-                    // workspace declaration. The package uses license-file (non-SPDX
-                    // SySL-1.0) for crates.io compatibility, so the textual license
-                    // id lives only in [workspace.package].
-                    let lic = t.get("license").and_then(|x| x.as_str()).or_else(|| {
-                        v.get("workspace")
-                            .and_then(|w| w.get("package"))
-                            .and_then(|p| p.get("license"))
-                            .and_then(|x| x.as_str())
-                    });
-                    if let Some(lic) = lic {
->>>>>>> origin/dev
                         pj.insert("license".to_string(), TomlValue::String(lic.to_string()));
                     }
                     if let Some(auth) = t.get("authors").and_then(|x| x.as_array()) {

--- a/docs/es/API_MODBUS_MASTER.md
+++ b/docs/es/API_MODBUS_MASTER.md
@@ -213,9 +213,5 @@ fn main() -> Result<()> {
 ## 8. Próximos pasos
 
 - Para las APIs del lado esclavo, consulta `examples/api_slave`.
-<<<<<<< HEAD
 - Para el uso de Modbus a nivel de CLI, consulta `docs/en/CLI_MODBUS.md`.
-=======
-- Para el uso de Modbus a nivel de CLI, consulta `docs/es/CLI_MODBUS.md`.
->>>>>>> origin/dev
 - Para la exportación de datos vía HTTP / MQTT / IPC, consulta los documentos `DATA_SOURCE_*.md` en este directorio.

--- a/docs/es/API_MODBUS_SLAVE.md
+++ b/docs/es/API_MODBUS_SLAVE.md
@@ -149,12 +149,7 @@ Puedes combinar esto con el ejemplo master o la CLI/TUI de Aoba para pruebas:
 
 ## 7. Documentación relacionada
 
-<<<<<<< HEAD
 - API del lado master: `docs/en/API_MODBUS_MASTER.md`;
 - Uso de Modbus a nivel de CLI: `docs/en/CLI_MODBUS.md`;
-=======
-- API del lado master: `docs/es/API_MODBUS_MASTER.md`;
-- Uso de Modbus a nivel de CLI: `docs/es/CLI_MODBUS.md`;
->>>>>>> origin/dev
 - Capacidades de fuente de datos / exportación (HTTP, MQTT, IPC, etc.): consulta los documentos `DATA_SOURCE_*.md` en este directorio;
 - Más ejemplos de extremo a extremo se encuentran en el directorio `examples`.

--- a/docs/fr/API_MODBUS_MASTER.md
+++ b/docs/fr/API_MODBUS_MASTER.md
@@ -213,9 +213,5 @@ fn main() -> Result<()> {
 ## 8. Prochaines étapes
 
 - Pour les APIs côté esclave, voir `examples/api_slave`.
-<<<<<<< HEAD
 - Pour l'utilisation Modbus en ligne de commande, voir `docs/en/CLI_MODBUS.md`.
-=======
-- Pour l'utilisation Modbus en ligne de commande, voir `docs/fr/CLI_MODBUS.md`.
->>>>>>> origin/dev
 - Pour l'export de données via HTTP / MQTT / IPC, consultez les documentations `DATA_SOURCE_*.md` dans ce répertoire.

--- a/docs/fr/API_MODBUS_SLAVE.md
+++ b/docs/fr/API_MODBUS_SLAVE.md
@@ -149,12 +149,7 @@ Vous pouvez le coupler avec l'exemple master ou l'interface CLI/TUI d'Aoba pour 
 
 ## 7. Documentation connexe
 
-<<<<<<< HEAD
 - API côté master : `docs/en/API_MODBUS_MASTER.md` ;
 - Utilisation Modbus en ligne de commande : `docs/en/CLI_MODBUS.md` ;
-=======
-- API côté master : `docs/fr/API_MODBUS_MASTER.md` ;
-- Utilisation Modbus en ligne de commande : `docs/fr/CLI_MODBUS.md` ;
->>>>>>> origin/dev
 - Capacités de source de données / export (HTTP, MQTT, IPC, etc.) : consultez les documents `DATA_SOURCE_*.md` dans ce répertoire ;
 - D'autres exemples de bout en bout se trouvent dans le répertoire `examples`.

--- a/docs/ja/API_MODBUS_MASTER.md
+++ b/docs/ja/API_MODBUS_MASTER.md
@@ -213,9 +213,5 @@ fn main() -> Result<()> {
 ## 8. 次のステップ
 
 - スレーブ側 API については、`examples/api_slave` を参照してください。
-<<<<<<< HEAD
 - CLI レベルの Modbus 利用については、`docs/en/CLI_MODBUS.md` を参照してください。
-=======
-- CLI レベルの Modbus 利用については、`docs/ja/CLI_MODBUS.md` を参照してください。
->>>>>>> origin/dev
 - HTTP / MQTT / IPC 経由のデータエクスポートについては、このディレクトリ内の `DATA_SOURCE_*.md` ドキュメントを参照してください。

--- a/docs/ja/API_MODBUS_SLAVE.md
+++ b/docs/ja/API_MODBUS_SLAVE.md
@@ -149,12 +149,7 @@ cargo run --package api_slave -- /tmp/vcom2
 
 ## 7. 関連ドキュメント
 
-<<<<<<< HEAD
 - マスター側 API: `docs/en/API_MODBUS_MASTER.md`
 - CLI レベルの Modbus 利用: `docs/en/CLI_MODBUS.md`
-=======
-- マスター側 API: `docs/ja/API_MODBUS_MASTER.md`
-- CLI レベルの Modbus 利用: `docs/ja/CLI_MODBUS.md`
->>>>>>> origin/dev
 - データソース / エクスポート機能（HTTP、MQTT、IPC など）: このディレクトリ内の `DATA_SOURCE_*.md` ドキュメントを参照してください。
 - その他のエンドツーエンドの例は `examples` ディレクトリにあります。

--- a/docs/ko/API_MODBUS_MASTER.md
+++ b/docs/ko/API_MODBUS_MASTER.md
@@ -213,9 +213,5 @@ fn main() -> Result<()> {
 ## 8. 다음 단계
 
 - 슬레이브 측 API는 `examples/api_slave`를 참조하십시오.
-<<<<<<< HEAD
 - CLI 수준의 Modbus 사용법은 `docs/en/CLI_MODBUS.md`를 참조하십시오.
-=======
-- CLI 수준의 Modbus 사용법은 `docs/ko/CLI_MODBUS.md`를 참조하십시오.
->>>>>>> origin/dev
 - HTTP / MQTT / IPC를 통한 데이터 내보내기는 이 디렉토리의 `DATA_SOURCE_*.md` 문서를 참조하십시오.

--- a/docs/ko/API_MODBUS_SLAVE.md
+++ b/docs/ko/API_MODBUS_SLAVE.md
@@ -149,12 +149,7 @@ cargo run --package api_slave -- /tmp/vcom2
 
 ## 7. 관련 문서
 
-<<<<<<< HEAD
 - 마스터 측 API: `docs/en/API_MODBUS_MASTER.md`;
 - CLI 수준 Modbus 사용법: `docs/en/CLI_MODBUS.md`;
-=======
-- 마스터 측 API: `docs/ko/API_MODBUS_MASTER.md`;
-- CLI 수준 Modbus 사용법: `docs/ko/CLI_MODBUS.md`;
->>>>>>> origin/dev
 - 데이터 소스 / 내보내기 기능 (HTTP, MQTT, IPC 등): 이 디렉토리의 `DATA_SOURCE_*.md` 문서를 참조하십시오;
 - 더 많은 엔드투엔드 예제는 `examples` 디렉토리에 있습니다.

--- a/docs/zht/API_MODBUS_MASTER.md
+++ b/docs/zht/API_MODBUS_MASTER.md
@@ -247,10 +247,6 @@ fn main() -> Result<()> {
 ## 8. 延伸閱讀
 
 - 從站側 API 使用範例：`examples/api_slave`；
-<<<<<<< HEAD
 - CLI 等級的 Modbus 使用說明：`docs/zhs/CLI_MODBUS.md`；
-=======
-- CLI 等級的 Modbus 使用說明：`docs/zht/CLI_MODBUS.md`；
->>>>>>> origin/dev
 - HTTP / MQTT / IPC 等資料來源對接文件：同目錄下 `DATA_SOURCE_*.md`；
 - 若要結合 TUI 做 E2E 測試，請參考 `examples/tui_e2e` 及根目錄下 `CLAUDE.md` 中關於 IPC 與狀態監控的介紹。

--- a/docs/zht/API_MODBUS_SLAVE.md
+++ b/docs/zht/API_MODBUS_SLAVE.md
@@ -152,12 +152,7 @@ cargo run --package api_slave -- /tmp/vcom2
 
 ## 7. 延伸閱讀
 
-<<<<<<< HEAD
 - 主站側 API 使用範例：`docs/zhs/API_MODBUS_MASTER.md`；
 - CLI 等級 Modbus 使用說明：`docs/zhs/CLI_MODBUS.md`；
-=======
-- 主站側 API 使用範例：`docs/zht/API_MODBUS_MASTER.md`；
-- CLI 等級 Modbus 使用說明：`docs/zht/CLI_MODBUS.md`；
->>>>>>> origin/dev
 - 資料來源/資料出口能力（HTTP、MQTT、IPC 等）：同目錄下 `DATA_SOURCE_*.md` 文件；
 - 更多綜合範例可參考 `examples` 目錄中的其他子專案。

--- a/examples/api_master/Cargo.toml
+++ b/examples/api_master/Cargo.toml
@@ -1,17 +1,7 @@
 [package]
 name = "api_master"
-<<<<<<< HEAD
 version = "0.1.0"
 edition.workspace = true
-=======
-description.workspace = true
-repository.workspace = true
-license.workspace = true
-authors.workspace = true
-version.workspace = true
-edition.workspace = true
-publish = false
->>>>>>> origin/dev
 
 [dependencies]
 _main = { path = "../..", package = "aoba" }

--- a/examples/api_slave/Cargo.toml
+++ b/examples/api_slave/Cargo.toml
@@ -1,17 +1,7 @@
 [package]
 name = "api_slave"
-<<<<<<< HEAD
 version = "0.1.0"
 edition.workspace = true
-=======
-description.workspace = true
-repository.workspace = true
-license.workspace = true
-authors.workspace = true
-version.workspace = true
-edition.workspace = true
-publish = false
->>>>>>> origin/dev
 
 [dependencies]
 _main = { path = "../..", package = "aoba" }

--- a/examples/cli_e2e/src/e2e/write/write_coils.rs
+++ b/examples/cli_e2e/src/e2e/write/write_coils.rs
@@ -10,11 +10,7 @@ use _main::utils::{sleep_1s, sleep_3s};
 ///
 /// Test flow:
 /// 1. Start master on port1 in listen-persist mode
-<<<<<<< HEAD
 /// 2. Start slave on port2 in listen-persist mode  
-=======
-/// 2. Start slave on port2 in listen-persist mode
->>>>>>> origin/dev
 /// 3. Use TUI/IPC to send register updates to slave with update_reason="user_edit"
 /// 4. Slave sends write requests to master
 /// 5. Verify master received the writes

--- a/scripts/enforce_use_groups.py
+++ b/scripts/enforce_use_groups.py
@@ -687,17 +687,10 @@ def main() -> int:
     print("Starting use statement enforcement...")
     print(f"Working directory: {Path.cwd()}")
     print(f"Python version: {sys.version}")
-<<<<<<< HEAD
     
     changed: List[str] = []
     total_files = 0
     
-=======
-
-    changed: List[str] = []
-    total_files = 0
-
->>>>>>> origin/dev
     for path in Path.cwd().rglob("*.rs"):
         if "target" in path.parts:
             continue
@@ -807,11 +800,7 @@ if __name__ == "__main__":
         print("="*80)
         print("ENFORCE USE STATEMENT GROUPS")
         print("="*80)
-<<<<<<< HEAD
         
-=======
-
->>>>>>> origin/dev
         # Check for test mode
         if "--test" in sys.argv:
             print("Running in test mode...")
@@ -822,11 +811,7 @@ if __name__ == "__main__":
         print("Loading workspace crates...")
         WORKSPACE_CRATES = load_workspace_crates(Path.cwd())
         print(f"Found {len(WORKSPACE_CRATES)} workspace crates")
-<<<<<<< HEAD
         
-=======
-
->>>>>>> origin/dev
         exit_code = main()
         print(f"Exiting with code: {exit_code}")
         sys.exit(exit_code)

--- a/scripts/run_api_test.py
+++ b/scripts/run_api_test.py
@@ -20,11 +20,7 @@ from pathlib import Path
 
 class ProcessRunner:
     """Run a process and prefix its output"""
-<<<<<<< HEAD
     
-=======
-
->>>>>>> origin/dev
     def __init__(self, name: str, cmd: list, prefix: str, color_code: str):
         self.name = name
         self.cmd = cmd
@@ -32,11 +28,7 @@ class ProcessRunner:
         self.color_code = color_code
         self.process = None
         self.thread = None
-<<<<<<< HEAD
         
-=======
-
->>>>>>> origin/dev
     def stream_output(self, stream, is_stderr=False):
         """Stream output from process with prefix"""
         stream_name = "stderr" if is_stderr else "stdout"
@@ -47,19 +39,11 @@ class ProcessRunner:
                     print(f"{self.color_code}[{self.prefix}]{self._reset_color()} {decoded}", flush=True)
         except Exception as e:
             print(f"{self.color_code}[{self.prefix}]{self._reset_color()} Error reading {stream_name}: {e}", flush=True)
-<<<<<<< HEAD
     
     def _reset_color(self):
         """Reset terminal color"""
         return "\033[0m"
     
-=======
-
-    def _reset_color(self):
-        """Reset terminal color"""
-        return "\033[0m"
-
->>>>>>> origin/dev
     def start(self):
         """Start the process"""
         print(f"{self.color_code}[{self.prefix}]{self._reset_color()} Starting: {' '.join(self.cmd)}")
@@ -69,11 +53,7 @@ class ProcessRunner:
             stderr=subprocess.PIPE,
             bufsize=1
         )
-<<<<<<< HEAD
         
-=======
-
->>>>>>> origin/dev
         # Start threads to stream stdout and stderr
         self.thread_stdout = threading.Thread(
             target=self.stream_output,
@@ -85,30 +65,17 @@ class ProcessRunner:
             args=(self.process.stderr, True),
             daemon=True
         )
-<<<<<<< HEAD
         
         self.thread_stdout.start()
         self.thread_stderr.start()
         
         return self.process
     
-=======
-
-        self.thread_stdout.start()
-        self.thread_stderr.start()
-
-        return self.process
-
->>>>>>> origin/dev
     def wait(self):
         """Wait for process to complete"""
         if self.process:
             return self.process.wait()
-<<<<<<< HEAD
     
-=======
-
->>>>>>> origin/dev
     def terminate(self):
         """Terminate the process"""
         if self.process:
@@ -128,19 +95,11 @@ def main():
     parser.add_argument('--duration', type=int, default=0, help='Test duration in seconds (0 = run until Ctrl+C)')
     parser.add_argument('--no-build', action='store_true', help='Skip auto-build step (use existing binaries)')
     args = parser.parse_args()
-<<<<<<< HEAD
     
     # Find project root
     script_dir = Path(__file__).parent
     project_root = script_dir.parent
     
-=======
-
-    # Find project root
-    script_dir = Path(__file__).parent
-    project_root = script_dir.parent
-
->>>>>>> origin/dev
     print("=" * 80)
     print("🚀 Modbus Master/Slave Communication Test")
     print("=" * 80)
@@ -149,7 +108,6 @@ def main():
     print(f"⏱️  Duration:    {'Unlimited (Ctrl+C to stop)' if args.duration == 0 else f'{args.duration} seconds'}")
     print("=" * 80)
     print()
-<<<<<<< HEAD
     
     # ANSI color codes
     COLOR_MASTER = "\033[94m"  # Blue
@@ -159,17 +117,6 @@ def main():
     slave_bin = project_root / "target" / "debug" / "api_slave"
     master_bin = project_root / "target" / "debug" / "api_master"
     
-=======
-
-    # ANSI color codes
-    COLOR_MASTER = "\033[94m"  # Blue
-    COLOR_SLAVE = "\033[92m"   # Green
-
-    # Check if binaries exist, if not build them
-    slave_bin = project_root / "target" / "debug" / "api_slave"
-    master_bin = project_root / "target" / "debug" / "api_master"
-
->>>>>>> origin/dev
     if not args.no_build and (not slave_bin.exists() or not master_bin.exists()):
         print("🔨 Building examples...")
         subprocess.run(
@@ -179,11 +126,7 @@ def main():
         )
         print("✅ Build completed")
         print()
-<<<<<<< HEAD
     
-=======
-
->>>>>>> origin/dev
     # Create process runners using pre-built binaries
     slave = ProcessRunner(
         name="Slave",
@@ -191,27 +134,18 @@ def main():
         prefix="SLAVE",
         color_code=COLOR_SLAVE
     )
-<<<<<<< HEAD
     
-=======
-
->>>>>>> origin/dev
     master = ProcessRunner(
         name="Master",
         cmd=[str(master_bin), args.master_port],
         prefix="MASTER",
         color_code=COLOR_MASTER
     )
-<<<<<<< HEAD
     
-=======
-
->>>>>>> origin/dev
     try:
         # Start slave first (it needs to be listening)
         print("📡 Starting slave (listener)...")
         slave.start()
-<<<<<<< HEAD
         
         # Wait a bit for slave to initialize
         print("⏳ Waiting 3 seconds for slave to initialize...")
@@ -221,27 +155,12 @@ def main():
         print("📡 Starting master (poller)...")
         master.start()
         
-=======
-
-        # Wait a bit for slave to initialize
-        print("⏳ Waiting 3 seconds for slave to initialize...")
-        time.sleep(3)
-
-        # Start master
-        print("📡 Starting master (poller)...")
-        master.start()
-
->>>>>>> origin/dev
         print()
         print("✅ Both processes started!")
         print("💡 Press Ctrl+C to stop both processes")
         print("=" * 80)
         print()
-<<<<<<< HEAD
         
-=======
-
->>>>>>> origin/dev
         # Wait for specified duration or until Ctrl+C
         if args.duration > 0:
             time.sleep(args.duration)
@@ -263,20 +182,12 @@ def main():
                     print("=" * 80)
                     print("❌ Master process terminated unexpectedly")
                     break
-<<<<<<< HEAD
     
-=======
-
->>>>>>> origin/dev
     except KeyboardInterrupt:
         print()
         print("=" * 80)
         print("🛑 Interrupted by user (Ctrl+C)")
-<<<<<<< HEAD
     
-=======
-
->>>>>>> origin/dev
     finally:
         print("=" * 80)
         print("🔄 Shutting down processes...")

--- a/scripts/socat_init.sh
+++ b/scripts/socat_init.sh
@@ -148,28 +148,16 @@ if [ "$MODE" = "tui_multiple" ]; then
   # For tui_multiple: create 6 virtual serial ports fully interconnected
   # Use a hub-and-spoke model where all ports connect to a central relay
   # This creates "大串联" - all ports can communicate with each other
-<<<<<<< HEAD
   
   # Create central FIFO hub
   HUB_FIFO="/tmp/aoba_hub_$$"
   mkfifo "$HUB_FIFO" || true
   
-=======
-
-  # Create central FIFO hub
-  HUB_FIFO="/tmp/aoba_hub_$$"
-  mkfifo "$HUB_FIFO" || true
-
->>>>>>> origin/dev
   # Create 6 PTY pairs, each connected through the hub
   # Note: This approach has limitations but works for our test purposes
   # In practice, serial port mesh networks are complex; we'll use simple pairs
   # but document the connectivity model
-<<<<<<< HEAD
   
-=======
-
->>>>>>> origin/dev
   echo "[socat_init] creating 6 virtual ports in 3 pairs for mesh connectivity"
   setsid socat -d -d PTY,link="$V1",raw,echo=0,mode=0666 PTY,link="$V2",raw,echo=0,mode=0666 2>"${LOG}.12" >/dev/null &
   PID1=$!
@@ -177,19 +165,11 @@ if [ "$MODE" = "tui_multiple" ]; then
   PID2=$!
   setsid socat -d -d PTY,link="$V5",raw,echo=0,mode=0666 PTY,link="$V6",raw,echo=0,mode=0666 2>"${LOG}.56" >/dev/null &
   PID3=$!
-<<<<<<< HEAD
   
   # Store PIDs for cleanup
   echo "${PID1} ${PID2} ${PID3}" >"$PIDFILE"
   disown "$PID1" "$PID2" "$PID3" 2>/dev/null || true
   
-=======
-
-  # Store PIDs for cleanup
-  echo "${PID1} ${PID2} ${PID3}" >"$PIDFILE"
-  disown "$PID1" "$PID2" "$PID3" 2>/dev/null || true
-
->>>>>>> origin/dev
   # Check if all processes started successfully
   if ! kill -0 "$PID1" 2>/dev/null || ! kill -0 "$PID2" 2>/dev/null || ! kill -0 "$PID3" 2>/dev/null; then
     echo "[socat_init] failed to start one or more socat processes"
@@ -198,15 +178,9 @@ if [ "$MODE" = "tui_multiple" ]; then
     rm -f "$HUB_FIFO" || true
     exit 1
   fi
-<<<<<<< HEAD
   
   echo "[socat_init] socat pids: ${PID1} ${PID2} ${PID3}, waiting for all 6 ports"
   
-=======
-
-  echo "[socat_init] socat pids: ${PID1} ${PID2} ${PID3}, waiting for all 6 ports"
-
->>>>>>> origin/dev
   # Wait for all PTYs to be created
   timeout=15
   count=0
@@ -214,11 +188,7 @@ if [ "$MODE" = "tui_multiple" ]; then
     sleep 1
     count=$((count + 1))
   done
-<<<<<<< HEAD
   
-=======
-
->>>>>>> origin/dev
   rm -f "$HUB_FIFO" || true
 else
   # Original 2-port mode
@@ -231,17 +201,10 @@ else
     echo "[socat_init] socat log ($LOG):"; tail -n 200 "$LOG" || true
     exit 1
   fi
-<<<<<<< HEAD
   
   SOCAT_PID=$(cat "$PIDFILE" 2>/dev/null || echo "")
   echo "[socat_init] socat pid: ${SOCAT_PID:-unknown}, waiting for $V1 and $V2"
   
-=======
-
-  SOCAT_PID=$(cat "$PIDFILE" 2>/dev/null || echo "")
-  echo "[socat_init] socat pid: ${SOCAT_PID:-unknown}, waiting for $V1 and $V2"
-
->>>>>>> origin/dev
   timeout=15
   count=0
   while [ $count -lt $timeout ] && ( [ ! -e "$V1" ] || [ ! -e "$V2" ] ); do

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
 ﻿pub mod input;
-=======
-pub mod input;
->>>>>>> origin/dev
 pub mod status;
 pub mod ui;
 pub mod utils;

--- a/src/tui/ui/pages/entry/render.rs
+++ b/src/tui/ui/pages/entry/render.rs
@@ -258,11 +258,7 @@ fn render_node_grid(
 /// Calculate the visible range of nodes based on selection position
 /// Strategy:
 /// - First 2 positions: show from start
-<<<<<<< HEAD
 /// - Last 2 positions: show from end  
-=======
-/// - Last 2 positions: show from end
->>>>>>> origin/dev
 /// - Middle positions: selected node at 3rd position (index 2 in view)
 fn calculate_visible_range(
     selection: usize,


### PR DESCRIPTION
Prevent future CI breakage: .cargo/config.toml was committed and could leak Windows absolute paths from register-patches. Untracked and added to .gitignore.