### PR TITLE
🔧 Route compute CI to local self-hosted runner.

### DIFF
--- a/.github/workflows/checks-autofix.yml
+++ b/.github/workflows/checks-autofix.yml
@@ -1,6 +1,7 @@
 name: Checks (autofix)
 
 on:
+  workflow_dispatch:
   push:
     branches: [master, dev]
 
@@ -14,7 +15,7 @@ jobs:
 
   fixes:
     name: Auto-fix and commit
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, local]
     needs: [check]
     # Ensure this job runs even if the upstream `check` job failed.
     # This lets the auto-fix steps attempt fixes and commit regardless of check result.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,6 +1,7 @@
 name: Checks
 
 on:
+  workflow_dispatch:
   push:
     branches: [master, dev]
   pull_request:
@@ -12,7 +13,9 @@ env:
 jobs:
   check:
     name: Check
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os == 'ubuntu-latest' && 'self-hosted' || matrix.os }}
+    if: github.event_name == 'workflow_dispatch' || matrix.os == 'ubuntu-latest'
+
     # Read-only permission: this job performs checks only.
     permissions:
       contents: read

--- a/.github/workflows/e2e-tests-cli.yml
+++ b/.github/workflows/e2e-tests-cli.yml
@@ -1,6 +1,7 @@
 name: CLI E2E Tests
 
 on:
+  workflow_dispatch:
   push:
     branches: [master, dev]
   pull_request:
@@ -11,7 +12,7 @@ env:
 jobs:
   cli-e2e-basic:
     name: CLI E2E Basic - ${{ matrix.module }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, local]
     strategy:
       fail-fast: false
       matrix:
@@ -79,7 +80,7 @@ jobs:
 
   cli-e2e-config-mode:
     name: CLI E2E Config Mode - ${{ matrix.module }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, local]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e-tests-tui.yml
+++ b/.github/workflows/e2e-tests-tui.yml
@@ -1,6 +1,7 @@
 name: TUI E2E Tests
 
 on:
+  workflow_dispatch:
   push:
     branches: [master, dev]
   pull_request:
@@ -12,7 +13,7 @@ jobs:
   # Rendering mode tests (screen-capture-only) - 23 modules
   tui-e2e-rendering:
     name: TUI E2E Rendering - ${{ matrix.module }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, local]
     strategy:
       fail-fast: false
       matrix:
@@ -84,7 +85,7 @@ jobs:
   # Drill-down mode tests (full integration) - 23 modules
   tui-e2e-drilldown:
     name: TUI E2E Drill-down - ${{ matrix.module }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, local]
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Route compute-heavy Linux CI jobs to the org-level local self-hosted runner (labels: self-hosted, linux, x64, local).

- Linux compute jobs: keep auto-triggering on push/PR, now execute on the local runner.
- macOS/Windows matrix legs: manual `workflow_dispatch` only.
- Merge hooks (commit-msg-lint / pr-title-check / squash-msg-clean), tag/release workflows, and Pages deploys stay on GitHub-hosted runners.
- evernight: re-enables workflows previously paused via __billing-paused__.
- entelecheia: fixes a pre-existing YAML block-scalar bug in install-test.yml.