### PR TITLE
🐛 Fix matrix gate: split official OS legs into manual-only job.

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,8 +13,7 @@ env:
 jobs:
   check:
     name: Check
-    runs-on: ${{ matrix.os == 'ubuntu-latest' && 'self-hosted' || matrix.os }}
-    if: github.event_name == 'workflow_dispatch' || matrix.os == 'ubuntu-latest'
+    runs-on: [self-hosted, linux, x64, local]
 
     # Read-only permission: this job performs checks only.
     permissions:
@@ -22,7 +21,97 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
+        rust: [stable, nightly]
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+          components: rustfmt, clippy
+
+      - name: Install system dependencies (Linux)
+        if: startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libudev-dev pkg-config libx11-dev libxcb-shape0-dev libxcb-xfixes0-dev socat libssl-dev
+
+      - name: Install system dependencies (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew update
+          # macOS build runner provides many libs; install pkg-config and socat which are commonly needed in CI
+          brew install pkg-config socat || true
+
+      - name: Install system dependencies (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: bash
+        run: |
+          echo "Skipping Linux-only system deps on Windows; install additional required packages in other CI steps if necessary"
+
+      - name: Cache cargo registry
+        uses: actions/cache@v6
+        continue-on-error: true
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ matrix.os }}-${{ matrix.rust }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ matrix.os }}-${{ matrix.rust }}-cargo-
+            ${{ matrix.os }}-cargo-
+
+      - name: Ensure Python3 present
+        if: startsWith(matrix.os, 'ubuntu') && matrix.rust == 'stable'
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+
+      - name: Enforce use statement groups
+        id: enforce_use_groups
+        if: startsWith(matrix.os, 'ubuntu') && matrix.rust == 'stable'
+        run: |
+          python scripts/enforce_use_groups.py
+          if ! git diff --quiet; then
+            echo "::error::Use statements are not grouped correctly. Run scripts/enforce_use_groups.py locally."
+            git diff --name-only
+            exit 1
+          fi
+
+      - name: Check formatting
+        id: fmt_check
+        run: cargo fmt --all -- --check
+
+      - name: Check compilation
+        id: check
+        run: cargo check --all-targets --all-features
+
+      - name: Clippy lints
+        id: clippy_check
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Run unit tests
+        run: cargo test --lib
+
+  check-official:
+    name: Check
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ${{ matrix.os }}
+
+    # Read-only permission: this job performs checks only.
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
         rust: [stable, nightly]
 
     steps:


### PR DESCRIPTION
GitHub Actions forbids `matrix` context in job-level `if` (workflow parse error on master). Split each multi-OS matrix job into:
- `<job>`: local self-hosted, os [ubuntu-latest], auto-triggered
- `<job>-official`: GitHub-hosted macos/windows, manual workflow_dispatch only

Also fixes kei: packages/* workflow dirs were missing from the original PR.