### PR TITLE
🔧 Fix noa release download in CI validate job.

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -20,11 +20,12 @@ jobs:
           set -euo pipefail
           VERSION="${NOA_VERSION:-latest}"
           if [ "$VERSION" = "latest" ]; then
-            URL="https://github.com/celestia-island/noa/releases/latest/download/noa-x86_64-unknown-linux-gnu"
+            URL="https://github.com/celestia-island/noa/releases/latest/download/noa-linux-x86_64.tar.gz"
           else
-            URL="https://github.com/celestia-island/noa/releases/download/${VERSION}/noa-x86_64-unknown-linux-gnu"
+            URL="https://github.com/celestia-island/noa/releases/download/${VERSION}/noa-linux-x86_64.tar.gz"
           fi
-          curl -fsSL "$URL" -o /usr/local/bin/noa
+          curl -fsSL "$URL" -o /tmp/noa.tar.gz
+          tar -xzf /tmp/noa.tar.gz -C /usr/local/bin noa
           chmod +x /usr/local/bin/noa
 
       - name: Check PR title


### PR DESCRIPTION
## P2 D5（全家族 CI）
- `Install noa` 步骤下载资产名错误（noa-x86_64-unknown-linux-gnu 404）→ 改为真实资产 noa-linux-x86_64.tar.gz（tar 解包）
- 16 仓同步修复 + noa 仓模板源头修复；保留 NOA_VERSION 覆盖与各变体语义；runs-on 等一律未动