### PR TITLE
🛡️ Pin cache-apt-pkgs-action and cargo-release to stable versions.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
-      - run: cargo install cargo-release
+      - run: cargo install cargo-release --version 1.1.4
 
       - run: cargo login ${{ secrets.CRATES_IO_API_TOKEN }}
       - run: |-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: System Packages — Cache (Linux only)
         if: matrix.platform.os == 'ubuntu-24.04' || matrix.platform.os == 'ubuntu-24.04-arm'
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.3
         with:
           packages: |
             build-essential
@@ -93,7 +93,7 @@ jobs:
 
       - name: System Packages — Cache (i686 — 32-bit libs)
         if: matrix.platform.target == 'i686-unknown-linux-gnu'
-        uses: awalsh128/cache-apt-pkgs-action@latest
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.3
         with:
           packages: |
             gcc-multilib


### PR DESCRIPTION
## P9#D2 + P9#D5 — CI supply chain hardening

### D2: pin `awalsh128/cache-apt-pkgs-action` (was `@latest`)
- `.github/workflows/release.yml:71` — `@latest` → `@v1.6.3`
- `.github/workflows/release.yml:96` — `@latest` → `@v1.6.3`
- Version source: `gh api repos/awalsh128/cache-apt-pkgs-action/releases/latest --jq .tag_name` → `v1.6.3` (latest stable release, checked 2026-08-08).

### D5: pin `cargo install cargo-release`
- `.github/workflows/publish.yml:22` — `cargo install cargo-release` → `cargo install cargo-release --version 1.1.4`
- Version source: crates.io API max_stable_version → 1.1.4.
- Note: task assumed the install also exists in checks.yml/release.yml; audit found it only in publish.yml — nothing to change there.
- No other unpinned `cargo install` remains (docs.yml uses org-internal git install of lagrange, kept as-is).

Validation: `python3 -c yaml.safe_load` on both files passed; diff limited to workflow files.