### PR TITLE
🛡️ Guard self-hosted jobs against fork pull requests.

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,6 +14,7 @@ jobs:
   check:
     name: Check
     runs-on: [self-hosted, linux, x64, local]
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
     # Read-only permission: this job performs checks only.
     permissions:

--- a/.github/workflows/e2e-tests-cli.yml
+++ b/.github/workflows/e2e-tests-cli.yml
@@ -13,6 +13,7 @@ jobs:
   cli-e2e-basic:
     name: CLI E2E Basic - ${{ matrix.module }}
     runs-on: [self-hosted, linux, x64, local]
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/e2e-tests-tui.yml
+++ b/.github/workflows/e2e-tests-tui.yml
@@ -14,6 +14,7 @@ jobs:
   tui-e2e-rendering:
     name: TUI E2E Rendering - ${{ matrix.module }}
     runs-on: [self-hosted, linux, x64, local]
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
P9#D1：自托管 runner 的 pull_request job 加 fork 守卫（github.event.pull_request.head.repo.full_name == github.repository），防止 fork PR 不可信代码在共享 node-1 上执行。